### PR TITLE
Improve construction of error classes

### DIFF
--- a/include/addrinfo_error.hpp
+++ b/include/addrinfo_error.hpp
@@ -15,7 +15,14 @@
 namespace locket {
 class addrinfo_error : public socket_error {
 public:
-  enum class func { getaddrinfo, getnameinfo };
+  enum class func { getaddrinfo = 0, getnameinfo = 1 };
+
+public:
+  static std::string gai_strerror_wrapper(int errno_num);
+
+private:
+  static constexpr conversion_func m_k_default_errno_to_string{
+      &gai_strerror_wrapper};
 
 public:
   addrinfo_error(func function, int errno_num);
@@ -23,6 +30,9 @@ public:
   addrinfo_error(addrinfo_error &&other) noexcept;
 
   virtual ~addrinfo_error() override;
+
+protected:
+  addrinfo_error(func function, int errno_num, conversion_func errno_to_string);
 
 public:
   virtual const char *what() const noexcept override;
@@ -34,7 +44,6 @@ public:
   addrinfo_error &operator=(addrinfo_error &&other) noexcept;
 
 private:
-  virtual std::string errno_to_string(int errno_num) const override;
   static std::string func_to_string(func function);
 };
 } // namespace locket

--- a/include/errno_error.hpp
+++ b/include/errno_error.hpp
@@ -10,9 +10,19 @@
 
 namespace locket {
 class errno_error : public std::runtime_error {
+protected:
+  using conversion_func = std::string (*)(int);
+
+public:
+  static std::string strerror_threadsafe(int errno_num);
+
 private:
   int m_errno_num;
-  mutable std::string m_errno_str;
+  std::string m_errno_str;
+
+private:
+  static constexpr conversion_func m_k_default_errno_to_string{
+      &strerror_threadsafe};
 
 public:
   errno_error(const std::string &what_arg, int errno_num);
@@ -22,6 +32,12 @@ public:
 
   virtual ~errno_error();
 
+protected:
+  errno_error(const std::string &what_arg, int errno_num,
+              conversion_func errno_to_string);
+  errno_error(const char *what_arg, int errno_num,
+              conversion_func errno_to_string);
+
 public:
   virtual const char *what() const noexcept;
   virtual int get_errno() const noexcept;
@@ -30,12 +46,6 @@ public:
 public:
   errno_error &operator=(const errno_error &other) noexcept;
   errno_error &operator=(errno_error &&other) noexcept;
-
-protected:
-  virtual std::string errno_to_string(int errno_num) const;
-
-public:
-  static std::string strerror_threadsafe(int errno_num);
 };
 } // namespace locket
 

--- a/include/socket_error.hpp
+++ b/include/socket_error.hpp
@@ -12,6 +12,10 @@
 
 namespace locket {
 class socket_error : public errno_error {
+private:
+  static constexpr conversion_func m_k_default_errno_to_string{
+      &errno_error::strerror_threadsafe};
+
 public:
   socket_error(const std::string &what_arg, int errno_num);
   socket_error(const char *what_arg, int errno_num);
@@ -19,6 +23,12 @@ public:
   socket_error(socket_error &&other) noexcept;
 
   virtual ~socket_error();
+
+protected:
+  socket_error(const std::string &what_arg, int errno_num,
+               conversion_func errno_to_string);
+  socket_error(const char *what_arg, int errno_num,
+               conversion_func errno_to_string);
 
 public:
   virtual const char *what() const noexcept override;
@@ -28,9 +38,6 @@ public:
 public:
   socket_error &operator=(const socket_error &other) noexcept;
   socket_error &operator=(socket_error &&other) noexcept;
-
-private:
-  virtual std::string errno_to_string(int errno_num) const override;
 };
 } // namespace locket
 

--- a/src/socket_error.cpp
+++ b/src/socket_error.cpp
@@ -10,10 +10,10 @@
 #include <utility>
 
 locket::socket_error::socket_error(const std::string &what_arg, int errno_num)
-    : errno_error{what_arg, errno_num} {}
+    : socket_error{what_arg, errno_num, nullptr} {}
 
 locket::socket_error::socket_error(const char *what_arg, int errno_num)
-    : errno_error{what_arg, errno_num} {}
+    : socket_error{what_arg, errno_num, nullptr} {}
 
 locket::socket_error::socket_error(const socket_error &other) noexcept
     : errno_error{other} {}
@@ -22,6 +22,20 @@ locket::socket_error::socket_error(socket_error &&other) noexcept
     : errno_error{std::move(other)} {}
 
 locket::socket_error::~socket_error() {}
+
+locket::socket_error::socket_error(const std::string &what_arg, int errno_num,
+                                   conversion_func errno_to_string)
+    : errno_error{what_arg, errno_num,
+                  ((errno_to_string != nullptr)
+                       ? (errno_to_string)
+                       : (m_k_default_errno_to_string))} {}
+
+locket::socket_error::socket_error(const char *what_arg, int errno_num,
+                                   conversion_func errno_to_string)
+    : errno_error{what_arg, errno_num,
+                  ((errno_to_string != nullptr)
+                       ? (errno_to_string)
+                       : (m_k_default_errno_to_string))} {}
 
 const char *locket::socket_error::what() const noexcept {
   return errno_error::what();
@@ -55,8 +69,4 @@ locket::socket_error::operator=(socket_error &&other) noexcept {
   errno_error::operator=(std::move(other));
 
   return *this;
-}
-
-std::string locket::socket_error::errno_to_string(int errno_num) const {
-  return errno_error::errno_to_string(errno_num);
 }


### PR DESCRIPTION
The error classes encapsulating `errno` were originally converting the numeric error code to a string representation when the getter for that string was called, not during construction. This was to mimic virtual functions so that the right errno-to-string function was called (i.e. `errno_error` would use `strerror()` and `addrinfo_error` would use `gai_strerror()`). While it did work, this was inefficient and rather poor design (in my opinion). 

This commit remedies that by adding a set of `protected` constructors to these error classes that except a function pointer that points to the appropriate errno-to-string function. The idea is that a more-derived error class can pass an appropriate function to the base class constructor. The most-base error class constructor will then convert the `errno` to the appropriate string representation using the function that has been passed down the hierarchy through constructors. 

The public interface remains unchanged.